### PR TITLE
Add Policy Management Documentation

### DIFF
--- a/design/policy-management/diagrams/metadata-policy.plantuml
+++ b/design/policy-management/diagrams/metadata-policy.plantuml
@@ -1,0 +1,41 @@
+@startuml
+
+title Sequence Diagram for new metadata policy change
+participant AdminApi
+participant PolicyMgmt
+participant MonitorMgmt
+
+group save updated policy
+AdminApi-->PolicyMgmt: Metadata Policy action
+PolicyMgmt-->PolicyMgmt: get Policy by Id
+PolicyMgmt-->PolicyMgmt: update and save Policy
+end
+
+group generate event for each tenant
+PolicyMgmt-->PolicyMgmt: get tenants in policy scope
+loop for each tenant
+   PolicyMgmt-->UMB: send MetadataPolicyEvent
+   note right
+     MetadataPolicyEvent
+     :tenantId
+     :policyId
+   end note
+end
+UMB-->MonitorMgmt: consume MetadataPolicyEvent
+end
+
+group update monitors with new value
+MonitorMgmt-->PolicyMgmt: Get effective metadata policies for tenant
+note right
+     Proceed only if policyId
+     is in effective list
+end note
+
+MonitorMgmt-->MonitorMgmt: Get all monitors using metadata field
+MonitorMgmt-->MonitorMgmt: Get all bound monitors in list of monitor ids
+MonitorMgmt-->MonitorMgmt: Update rendered content for each bound monitor
+
+MonitorMgmt-->UMB: send bind/unbind events
+end
+
+@enduml

--- a/design/policy-management/diagrams/monitor-policy-create.plantuml
+++ b/design/policy-management/diagrams/monitor-policy-create.plantuml
@@ -1,0 +1,76 @@
+@startuml
+
+title Sequence Diagram for new monitor policy
+participant AdminApi
+participant PolicyMgmt
+participant MonitorMgmt
+
+group create new policy monitor
+AdminApi->MonitorMgmt: POST /policy-monitors
+note right
+// null params will use policy metadata
+{
+  "name": "ping",
+  "labelSelector": {},
+  "interval": null,
+  "labelSelectorMethod": null,
+  "details": {
+    "type": "remote",
+    "monitoringZones": null,
+    "plugin": {
+      "type": "ping",
+      "target": null
+    }
+  }
+}
+end note
+end
+
+group save new policy
+AdminApi-->PolicyMgmt: Monitor Policy action
+PolicyMgmt-->PolicyMgmt: save new policy
+end
+
+group generate event for each tenant
+PolicyMgmt-->PolicyMgmt: get tenants in policy scope
+loop for each tenant
+   PolicyMgmt-->UMB: send MonitorPolicyEvent
+   note right
+     MonitorPolicyEvent
+     :monitorId
+     :policyId
+     :tenantId
+   end note
+end
+UMB-->MonitorMgmt: consume MonitorPolicyEvent
+end
+
+group handleMonitorPolicyEvent
+MonitorMgmt-->PolicyMgmt: get effective policies for tenant
+MonitorMgmt-->MonitorMgmt: get monitor tied to policy monitor
+opt if policy is not in effect but monitor exists
+MonitorMgmt-->MonitorMgmt: remove bound monitors
+MonitorMgmt-->MonitorMgmt: remove monitor
+else if policy is in effect and monitor not found
+group clone monitor to new tenant
+MonitorMgmt-->MonitorMgmt: deep copy policy monitor
+MonitorMgmt-->MonitorMgmt: set new tenantId on monitor
+MonitorMgmt-->MonitorMgmt: set new policyId on monitor
+MonitorMgmt-->PolicyMgmt: get monitor metadata policies for tenant
+MonitorMgmt-->MonitorMgmt: update monitorMetadataFields
+MonitorMgmt-->PolicyMgmt: get plugin metadata policies for tenant
+MonitorMgmt-->MonitorMgmt: update pluginMetadataFields
+MonitorMgmt-->MonitorMgmt: save monitor with new id
+MonitorMgmt-->MonitorMgmt: bind monitor
+end
+else otherwiseno action is needed
+end
+MonitorMgmt-->UMB: send bind/unbind events
+end
+note right
+  This section is duplicated on a few
+  diagrams. If it changes, ensure all
+  are updated.
+end note
+@enduml
+

--- a/design/policy-management/diagrams/monitor-policy-update.plantuml
+++ b/design/policy-management/diagrams/monitor-policy-update.plantuml
@@ -1,0 +1,71 @@
+@startuml
+
+title Sequence Diagram for updating a monitor policy
+
+note left of AdminAPI #aqua
+Note: Only the scope of a monitor policy can be modified.
+
+The ability to update policies is required
+to ensure the monitor id on a tenant doesn't change
+just because the policy's scope was altered.
+If the tenant is no longer in the scope of the policy
+its monitor will be removed but for those who are still in scope,
+it is beneficial to keep the cloned monitor id consistent so
+that business processes relying on it can continue to work.
+
+There's a chance newer processes will not tie directly to
+the monitor id, but it's best to not rely on that assumption as long as
+this process doesn't add large amounts of complexity.
+end note
+
+participant AdminAPI
+participant MonitorMgmt
+participant PolicyMgmt
+
+AdminAPI-->PolicyMgmt: update Policy with new scope
+PolicyMgmt-->PolicyMgmt: save new Policy
+
+group generate event for each tenant
+PolicyMgmt-->PolicyMgmt: get tenants in old policy scope
+PolicyMgmt-->PolicyMgmt: get tenants in new policy scope
+loop for each unique tenant
+   PolicyMgmt-->UMB: send MonitorPolicyEvent
+   note right
+     MonitorPolicyEvent
+     :tenantId
+     :policyId
+     :monitorId
+   end note
+end
+UMB-->MonitorMgmt: consume MonitorPolicyEvent
+end
+
+group handleMonitorPolicyEvent
+MonitorMgmt-->PolicyMgmt: get effective policies for tenant
+MonitorMgmt-->MonitorMgmt: get monitor tied to policy monitor
+opt if policy is not in effect but monitor exists
+MonitorMgmt-->MonitorMgmt: remove bound monitors
+MonitorMgmt-->MonitorMgmt: remove monitor
+else if policy is in effect and monitor not found
+group clone monitor to new tenant
+MonitorMgmt-->MonitorMgmt: deep copy policy monitor
+MonitorMgmt-->MonitorMgmt: set new tenantId on monitor
+MonitorMgmt-->MonitorMgmt: set new policyId on monitor
+MonitorMgmt-->PolicyMgmt: get monitor metadata policies for tenant
+MonitorMgmt-->MonitorMgmt: update monitorMetadataFields
+MonitorMgmt-->PolicyMgmt: get plugin metadata policies for tenant
+MonitorMgmt-->MonitorMgmt: update pluginMetadataFields
+MonitorMgmt-->MonitorMgmt: save monitor with new id
+MonitorMgmt-->MonitorMgmt: bind monitor
+end
+else otherwiseno action is needed
+end
+MonitorMgmt-->UMB: send bind/unbind events
+end
+note right
+  This section is duplicated on a few
+  diagrams. If it changes, ensure all
+  are updated.
+end note
+
+@enduml

--- a/design/policy-management/metadata-policy.md
+++ b/design/policy-management/metadata-policy.md
@@ -1,0 +1,101 @@
+# Metadata Policies
+
+## Problem
+
+We need to be able to automatically apply default values for individual monitor/task fields upon creation of those objects.  We also need to be able to update those values whenever new business decisions are made.
+
+For example, we may initially decide that all monitors should gather metrics once a minute with a timeout of 10s.  Whenever a customer creates a new monitor and does not specifically set their own value for the interval or timeout properties, we would then apply those defaults of 1min and 10s.  If the business later decided that we need to increase the timeout to 30s for any HTTP monitor, we should have a way to alter that value to impact any future monitor being created as well as automatically updating all existing HTTP monitors that use those defaults - the one catch is that if a customer happens to have set the value of 10s on their own and not relied on the default, we should not override it.
+
+The solution should allow customers to provide minimal details when creating new monitors or tasks.  Only the fields critical to them should be included and the application can populate defaults for everything else.
+
+
+## Solution
+
+The Policy Management application will introduce the concept of Metadata Policies, which contains subclasses for Monitor Metadata Policies and Task Metadata Policies.
+
+Any field on a monitor or task that is not annotated with `@NonMetadataField` may be populated by these metadata policies.
+
+The structure of the policies will allow for general values which can apply to any data type, or for the policy to narrow in on a specific plugin field.  For example, a policy to set a default value for the `followRedirects` field on http monitors would look like this:
+
+```json
+{
+  "scope": "GLOBAL",
+  "subscope": null,
+  "targetClassName": "RemotePlugin",
+  "monitorType": "http",
+  "valueType": "BOOL",
+  "key": "followRedirects",
+  "value": "true"
+}
+```
+
+
+### Applying Monitor Metadata to New Monitors
+
+If a new monitor payload includes any null/missing values, those fields will be queried in Policy Management to determine if an applicable metadata policy exists for that specific customer.  If it does, the `null` value will be overridden by the metadata value; additionally, the fact the monitor is utilizing that policy will also be stored as part of the `Monitor` object.
+
+#### Flow of events
+
+The API receives a `DetailedMonitorInput` which is passed through the conversion service to populate a `MonitorCU`.  During this process the plugin details are converted to a `String contents` using object mapper.  Prior to this being done a translation occurs to update the `null` values within the plugin details to their policy value.
+
+For example, if a ping check is created without a `count` value being set, we will use the policy api to retrieve the metadata relevant to a `ping`/`MonitorDetails` class.  The relevant values will be set and then the plugin details can be converted to the string contents to be saved on the Monitor class.
+
+During this we also pass the list of fields using policy metadata through via the `MonitorCU` as `pluginMetadataFields` to be stored later.  These will be used to identify which fields in the plugin details are using policy metadata.
+
+Next, the unset metadata fields on the Monitor object will be updated.  The policy api will be used to retrieve all metadata for the `ping`/`Monitor` class and the previously null ones will be set.  Similar to above, we will keep a list of what fields were applied here and store that list as part of the monitor as `monitorMetadataFields`.
+
+Once the metadata fields have been set, the monitor will be saved to the db and binding to resources will occur.
+
+
+### Updating an existing monitor to use a policy
+
+The `PATCH` method can be used via the API to reset a monitor's fields to their policy value instead of something custom.  Since the payload to a `PATCH` contains the specific operations to perform we can be sure that if `null` is provided that it really means `null` and that isn't wasn't simply not set - which could be the case in a `PUT` operation.
+
+To set the timeout of a monitor to the default policy value, the following payload could be provided.
+
+```json
+[
+  { "op": "replace", "path": "/details/plugin/timeout", "value": null }
+]
+```
+
+This will trigger similar logic to the monitor creation described above.  The application will query the policy API to retrieve the default value for `timeout` and apply it to the monitor while also tracking the fact a policy is now used for that value. 
+
+#### PUT Operations
+
+Due to the inability to know whether `null` provided in a `PUT` means to set the value to `null` or to leave it as it is you cannot use this method to apply policy metadata to a monitor.
+
+However, a `PUT` will also not remove a policy from a monitor if either the same value or a `null` is provided.
+
+For example, if the `interval` field is currently using a policy value of 30s and a `PUT` request comes through with the payload below, the application is aware enough to know that the monitor was previously using the 30s metadata value and since 30s has been provided here, it will leave it as is and still consider that field to be using the policy - if that policy was updated in future, this monitor would also be modified to match the new value.
+
+```json
+{
+  "interval": 30
+}
+```
+
+However, If a value of `60` was provided instead, the `interval` field would be removed from the list of policies in use by the monitor and future changes to that policy would have no impact on this monitor.
+
+
+### Updating Existing Metadata Policies
+
+If a metadata policy is updated via the Policy Management Admin API, unique `MetadataPolicyEvent`s will be produced to kafka for each tenant that has the potential to use the policy.  Monitor Management will consume these events and if it determines that the policy is actually in use by a tenant it will perform updates to each affected monitor.
+
+To perform this Monitor Management queries the `monitorMetadataFields` and `pluginMetadataFields` stored on each monitor.  These are the lists that store the names of the fields utilizing policy metadata.
+
+
+## Monitor Retrieval
+
+Since the monitor is stored with the policy values in place, no additional translation is required when serializing to an API response.  The monitor stored in the database is simply returned as normal.
+
+However, this means it will not be obvious to the customer which values are using policy metadata and which are custom.
+
+
+## Caching
+
+To limit the impact on customer facing API response times, a caching layer has been implemented in the Policy Api Client.  Each method in the client includes a parameter to state whether the cache should be hit or bypassed.
+
+Any operation a customer can perform such as creating or updating a monitor will always utilize the cache.  As policies do not change frequently (if ever), Monitor Management should rarely need to query policy management for that information.
+
+The only time the cache should not be utilized is if a policy has been updated.  Whenever Monitor Management consumes a `MetadataPolicyEvent` it will clear the cache for the relevant key.  This ensures that when a tenant's monitors are being updated to reflect the new policy value they will always receive the new value and not an old cached value.

--- a/design/policy-management/policy-managment.md
+++ b/design/policy-management/policy-managment.md
@@ -1,0 +1,242 @@
+# Overview
+This service is responsible for creating, updating, deleting, and distributing various default configurations.
+
+It is purely for internal use (behind an admin api) and is for general business logic; not to be provided for customers to create their own policies.
+
+## Initial Use Case
+The first use case we will handle is the default monitor configurations for new accounts
+
+Both Ping and SSH monitors should be configured at the global scope.
+
+Both monitors will be configured with all customizable fields set to `null` so that policy metadata will be used.  Each tenant that the monitor applies to may require different metadata values to be put in place.  See the documentation for Metadata Policies for more details on that.
+
+## High level explanation of initial use case actions
+This documents the process performed to create the first ping monitor from the use case above.
+
+1. We will use the Admin API to create one ping monitor
+    1. It will be configured just as you would via the public api but the use of policy metadata fields will be maximized (by setting almost every field to `null`)
+1. The monitor will be stored in the same `monitors` table as account level monitors
+    1. Except it will be stored using the tenant id of `_POLICY_`
+1. We will then use the Admin API to create a monitor policy
+    1. We will specify the following fields
+        1. scope: global
+        1. subscope: null (or just leave empty)
+        1. type: monitor
+        1. subtype: ping
+        1. value: the monitor id of the monitor created in step 1
+1. This will trigger a `MonitorPolicyEvent` to be sent to UMB for each tenant within the policy's scope
+1. Monitor Mgmt will consume those events and handle each individually
+1. Monitor Mgmt will query for all relevant monitor policies for that tenant
+1. Monitor Mgmt will clone the policy monitor to the tenant if the policy is applicable to the tenant
+1. Monitor Mgmt will perform the standard binding of a monitor
+1. `MonitorBoundEvent`s will be sent to UMB for consumption by the ambassador to process the new bindings.
+
+# In-Scope Features
+1. Default monitor configurations
+1. Default task configurations
+1. Default metadata
+   * Timeout
+   * Period/Frequency
+   * Monitoring zones
+   * Task thresholds
+   * Consecutive count / bake time
+   * Values stored would be things that we may want to change en-masse at some point
+1. Ability to opt out of a global default
+   * Some customers have agreements to not require Ping monitors
+
+# Out of Scope Features
+1. API Rate Limits
+   * These could potentially be stored here, but handled by another service
+1. Monitor Examples API
+   * This will be monitor configurations that could be applied/cloned to an account
+   * They will not be automatically applied via the global policy, but they will simplify the creation of new monitors for customers.
+1. Account feature flags
+   * This should be it's own policy type vs. being stored as metadata
+   * This is not yet needed, but I'm sure it will at some point.
+1. Notification Settings
+
+# Terms
+## Scope / Subscope
+All policies will created within a given `Scope`.
+
+Scopes are hierarchical and only the highest ranking scope relevant to the requesting tenant will be used.
+
+The available scopes all relate to tenants and their properties.  Device level scopes are not required as that is already handled by the label matching capabilities of monitors & tasks.
+
+For example, here are some possible scopes and their subscopes.
+
+1. Global
+1. Account Type
+   * RS Cloud
+   * Dedicated
+   * FAWS
+   * GCP
+   * Azure
+   * RPC
+1. SLA
+   * Managed
+   * Intensive
+   * Infrastructure
+1. Tenant
+   * ${tenantId}
+
+A priority value will be assigned to each scope type, so that when a request for data is made it can be ordered and only one value will be used.
+
+Some policies may only be set at the global scope, while others may be down to the SLA level.
+
+## Object Types
+### Monitor Policy
+Used to manage default monitor configurations across all tenants.  These control what tenants a specific policy monitor will be cloned and bound to.
+
+For example, a monitor policy created with the global scope may lead to the creation of a monitor on every single tenant we know of and then bound to all resources on that tenant.
+
+## Task Policy
+Used to manage default task configurations across all tenants.
+
+They act in the same way as monitor policies, but cause new tasks to be applied instead of monitors.  Typically we will have one task policy for each monitor policy.
+
+## Metadata Policy
+Used to define default values to be used in monitor and task configurations.
+
+When a new monitor or task is created, any field with a `null` value will be replaced with the corresponding metadata policy value if one exists.  If that policy changes in the future, the monitors or tasks using that policy will also be updated to reflect the change.
+
+See the Metadata Policy documentation for more details.
+
+## Tenant Metadata
+Used to provide tenant specific metadata.
+
+One common use case will be the `AccountType` of the tenant, which will be used to narrow down the specific monitor/task/metadata policies relating to this tenant.
+
+Another will be to override Monitor/Task policies to allow customers to opt out of the pre-defined policies.
+
+# Database
+
+The database stores `Policy` objects.  `Policy` is an abstract class containing `scope` and `subscope` fields and there will be numerous subclasses as defined below.
+
+Each subclass may have its own unique fields.
+
+## Monitor Policies
+These are stored in the `monitor_policies` tables with `name` and `monitor_id` fields along with their `scope `and `subscope`.
+
+  * `name` is a unique string to describe the monitor.
+     * It is used to group similar monitor policies across different subscopes
+     * e.g. the name "Ping" could be given to any Ping monitor policy so when looking up by tenant it is easy to pick the one effective policy
+  * `monitor_id` will reference the `id` of a monitor created under the `_POLICY_` tenant.
+
+### Example
+scope | subscope | name | monitor_id
+--- | --- | --- | ---
+Global | | Ping | 238a6013-aa09-40d9-a424-ac9429c85a4d
+Global | | SSH | aa3d55ba-7cc9-4cf9-96fe-81c4e8d19188
+AccountType | FAWS | AWS\_HTTP | 9c745f32-e0d8-4ac9-96d6-cb7515010b01
+Tenant | 12345 | SSH | null
+
+## Task Policies
+These will be stored in the `task_policies` tables with `name` and `task_id` fields along with their `scope `and `subscope`.
+
+The fields act in the same way as `Monitors` except they tie into the `tasks` table instead.
+
+### Example
+scope | subscope | name | task_id
+--- | --- | --- | ---
+Global | | Ping | 0d94f85d-8c8c-447f-a6e1-1b8278b4c157
+Global | | SSH | d24f3d5c-a35e-4998-bfbd-d57d59166cc7
+AccountType | FAWS | AWS\_HTTP | a749ba3c-8f74-4bb8-abe6-0931000916d4
+Tenant | 12345 | SSH | null
+
+## Tenant Metadata
+These are stored in the `tenant_metadata` table.
+
+The current known use-case involves us storing the account type of the tenant.
+
+## Example
+
+tenant_id | key | value
+--- | --- | ---
+hybrid:555433 | AccountType | Dedicated
+43243 | AccountType | Cloud
+56465 | AccountType | FAWS
+
+# Scenarios
+
+## Monitor Policy Creation / Deletion
+
+A new monitor policy creation will simply clone the monitor policy to the individual tenants effected by that policy and it will then act in the same way as any other monitor on their account.  The one exception is that these cloned monitors cannot be deleted from the tenant.  The method to remove a cloned policy monitor is to have that customer opt-out of the policy.
+
+If the policy is removed all cloned monitors and their corresponding bound monitors will be removed.
+
+1. A policy create (or delete) will occur via the Admin API
+1. This will cause a db operation within PolicyMgmt to save the new policy
+1. PolicyMgmt will then query for all tenants in the policy's scope
+1. PolicyMgmt will send out a MonitorPolicyEvent for each tenant
+   1. It will contain the policy id, the monitor id, and a single tenant id
+1. MonitorMgmt will consume the MonitorPolicyEvents
+1. For each event it will
+    1. Get the effective policies for the tenant
+    1. If the policy in the MonitorPolicyEvent is in effect
+        1. Clone the policy monitor
+        1. Set the customer tenant on the newly cloned monitor
+        1. Refresh the metadata fields on the monitor to reflect the metadata policies applied to this tenant
+        1. Link the cloned monitor to the policy monitor id by setting the policyId and policyMonitorId fields  
+        1. Save the cloned monitor to the customer tenant
+    1. If the policy in the MonitorPolicyEvent is not in effect
+        1. Get the customer monitor tied to the monitorId in the MonitorPolicyEvent
+        1. Remove all bound monitors tied to that monitor
+        1. Remove the customer monitor
+    1. Send bind/unbind events to UMB for the ambassador to process
+    
+![](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/racker/salus-docs/master/design/policy-management/diagrams/monitor-policy-create.plantuml)
+
+## A Monitor used within a Monitor Policy is updated
+
+If the policy monitor is updated it will not affect any customer currently using the policy but simply acts as an update to the template that will be used to clone any new monitors in future.
+
+As metadata policies should be used within a policy monitors fields, no change to the monitor should be significant enough to require a push out to every customer using it.
+
+In reality an update to a policy monitor will probably never happen.
+
+## A Monitor Policy is updated
+
+Only the scope of a monitor policy can be updated, not the actual monitor id used.
+
+This scenario documents the case where a monitor policy has already been in place and is applied to numerous resources, but then the scope of that policy is updated via the admin api.
+
+1. Tenant's that were previously in-scope and are still in-scope will remain unchanged.
+1. Tenant's that were not previously in-scope but are now will have the policy monitor cloned to their account.
+1. Tenant's that were in-scope but no longer are will have the cloned monitor and all related bound monitors removed for their account .
+
+![](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/racker/salus-docs/master/design/policy-management/diagrams/monitor-policy-update.plantuml)
+
+## New Resource Created
+Due to policy monitors being cloned to individual tenant's where needed, a new resource coming online will be able to treat all monitors the same.  The policy monitors related to the account will be returned by label matching in exactly the same way as their own created monitors.
+
+## Metadata Policy Change
+
+Metadata policy changes will act the same for monitors tied to a policy as it will for those created by an individual tenant.
+
+![](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/racker/salus-docs/master/design/policy-management/diagrams/metadata-policy.plantuml)
+
+# Opting Out
+Monitor Policies can be opted out of by creating a `null` policy of the same name for that tenant's scope.
+
+Using the same example as above, assuming these policies are in place:
+
+scope | subscope | name | monitor_id
+--- | --- | --- | ---
+Global | | Ping | 238a6013-aa09-40d9-a424-ac9429c85a4d
+Global | | SSH | aa3d55ba-7cc9-4cf9-96fe-81c4e8d19188
+AccountType | FAWS | AWS\_HTTP | 9c745f32-e0d8-4ac9-96d6-cb7515010b01
+Tenant | 12345 | SSH | null
+
+Tenant `12345` will never have a monitor cloned to them for the global ssh policy since they have a `null` policy in place with the same name.  Monitor Management may still receive a policy event with `tenantId: 12345, monitorId: aa3d55...` to process but due to the global policy not being in the list of effective policies for that tenant no action would be taken.
+
+# Notes
+
+## Monitor/Task Policy Deletions
+
+When these policies are deleted the actual monitor/task under the `_POLICY_` tenant is not removed, only the policy entry and all cloned monitors tied to that policy. 
+
+If a policy monitor used within a policy is to be removed, it must be done so via the admin api / monitor management after the policy utilizing it has already been removed and the deletion of all cloned monitors has been completed.
+
+## Other Dependencies
+The account type will have to be populated into tenant metadata somehow, otherwise only the global policies will be used.  This may be able to utilize UMB's account/device info receivers.


### PR DESCRIPTION
This consolidates the previous proposal related to Policy Managements handling of Monitor Policies and Metadata Policies.

The only changes from the previously agreed on details are file names (and therefore the plantuml links).